### PR TITLE
Allows for excluding spell id's from the module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CMakeLists.txt.user
 *.BACKUP.*
 *.BASE.*
 *.LOCAL.*
+*.conf
 
 #
 # IDE & other softwares

--- a/conf/mod_account_mount.conf.dist
+++ b/conf/mod_account_mount.conf.dist
@@ -12,6 +12,7 @@ Account.Mounts.Enable = 1
 
 Account.Mounts.Announce = 0
 
-# Excluded Spell IDs (comma-separated)
+# Excluded Spell IDs (comma-separated, no space). See example below
+# Account.Mounts.ExcludedSpellIDs = 470,578,6777
 
-Account.Mounts.ExcludedSpellIDs = 470,578,6777,66847,17464,18989,10969,10796,35020,34406
+Account.Mounts.ExcludedSpellIDs = 0

--- a/conf/mod_account_mount.conf.dist
+++ b/conf/mod_account_mount.conf.dist
@@ -11,3 +11,7 @@ Account.Mounts.Enable = 1
 # Announce the module when the player logs in?
 
 Account.Mounts.Announce = 0
+
+# Excluded Spell IDs (comma-separated)
+
+Account.Mounts.ExcludedSpellIDs = 470,578,6777,66847,17464,18989,10969,10796,35020,34406

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -2,26 +2,31 @@
 #include "ScriptMgr.h"
 #include "Chat.h"
 #include "Player.h"
-#include <sstream>
-#include <string>
+#include <set>         // Required for std::set             -- might be redundant
+#include <sstream>     // Required for std::istringstream   -- might be redundant
+#include <string>      // Required for std::string          -- might be redundant
 
 class AccountMounts : public PlayerScript
 {
     static const bool limitrace = true; // This set to true will only learn mounts from chars on the same team, do what you want.
-
-    // Define a list of SpellIDs in config file to exclude from being learned account-wide.
-    std::set<uint32> excludedSpellIds;
+    std::set<uint32> excludedSpellIds; // Set to hold the Spell IDs to be excluded
 
 public:
-    AccountMounts() : PlayerScript("AccountMounts") 
+    AccountMounts() : PlayerScript("AccountMounts")
     {
-        // Load excluded spell IDs from config
+        // Retrieve the string of excluded Spell IDs from the config file
         std::string excludedSpellsStr = sConfigMgr->GetStringDefault("Account.Mounts.ExcludedSpellIDs", "");
-        std::istringstream spellStream(excludedSpellsStr);
-        std::string spellIdStr;
-        while (std::getline(spellStream, spellIdStr, ',')) {
-            uint32 spellId = std::stoul(spellIdStr);
-            excludedSpellIds.insert(spellId);
+        // Proceed only if the configuration is not "0" or empty, indicating exclusions are specified
+        if (excludedSpellsStr != "0" && !excludedSpellsStr.empty())
+        {
+            std::istringstream spellStream(excludedSpellsStr);
+            std::string spellIdStr;
+            while (std::getline(spellStream, spellIdStr, ',')) {
+                uint32 spellId = static_cast<uint32>(std::stoul(spellIdStr));
+                if (spellId != 0) { // Ensure the spell ID is not 0, as 0 is used to indicate no exclusions
+                    excludedSpellIds.insert(spellId); // Add the Spell ID to the set of exclusions
+                }
+            }
         }
     }
     

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -13,7 +13,7 @@ class AccountMounts : public PlayerScript
     std::set<uint32> excludedSpellIds;
 
 public:
-    AccountMounts() : PlayerScript("AccountMounts")
+    AccountMounts() : PlayerScript("AccountMounts") 
     {
         // Load excluded spell IDs from config
         std::string excludedSpellsStr = sConfigMgr->GetStringDefault("Account.Mounts.ExcludedSpellIDs", "");
@@ -24,7 +24,7 @@ public:
             excludedSpellIds.insert(spellId);
         }
     }
-
+    
     void OnLogin(Player* pPlayer)
     {
         if (sConfigMgr->GetOption<bool>("Account.Mounts.Enable", true))

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -15,7 +15,7 @@ public:
     AccountMounts() : PlayerScript("AccountMounts")
     {
         // Retrieve the string of excluded Spell IDs from the config file
-        std::string excludedSpellsStr = sConfigMgr->GetStringDefault("Account.Mounts.ExcludedSpellIDs", "");
+        std::string excludedSpellsStr = sConfigMgr->GetOption<std::string>("Account.Mounts.ExcludedSpellIDs", "");
         // Proceed only if the configuration is not "0" or empty, indicating exclusions are specified
         if (excludedSpellsStr != "0" && !excludedSpellsStr.empty())
         {

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -13,7 +13,7 @@ class AccountMounts : public PlayerScript
     std::set<uint32> excludedSpellIds;
 
 public:
-    AccountMounts() : PlayerScript("AccountMounts") 
+    AccountMounts() : PlayerScript("AccountMounts")
     {
         // Load excluded spell IDs from config
         std::string excludedSpellsStr = sConfigMgr->GetStringDefault("Account.Mounts.ExcludedSpellIDs", "");
@@ -24,7 +24,7 @@ public:
             excludedSpellIds.insert(spellId);
         }
     }
-    
+
     void OnLogin(Player* pPlayer)
     {
         if (sConfigMgr->GetOption<bool>("Account.Mounts.Enable", true))

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -5,7 +5,10 @@
 
 class AccountMounts : public PlayerScript
 {
-    static const bool limitrace = false; // This set to true will only learn mounts from chars on the same team, do what you want.
+    static const bool limitrace = true; // This set to true will only learn mounts from chars on the same team, do what you want.
+
+    // Define a list of SpellIDs to exclude from being learned account-wide.
+    std::set<uint32> excludedSpellIds = {470, 578, 6777, 66847, 17464, 18989, 10969, 10796, 35020, 34406}; // Add the SpellIDs you want to exclude here.
 
 public:
     AccountMounts() : PlayerScript("AccountMounts") { }
@@ -32,7 +35,7 @@ public:
                 uint32 race = fields[1].Get<uint8>();
 
                 if ((Player::TeamIdForRace(race) == Player::TeamIdForRace(pPlayer->getRace())) || !limitrace)
-                    Guids.push_back(result1->Fetch()[0].Get<uint32>());
+                    Guids.push_back(fields[0].Get<uint32>());
 
             } while (result1->NextRow());
 
@@ -52,9 +55,13 @@ public:
 
             for (auto& i : Spells)
             {
-                auto sSpell = sSpellStore.LookupEntry(i);
-                if (sSpell->Effect[0] == SPELL_EFFECT_APPLY_AURA && sSpell->EffectApplyAuraName[0] == SPELL_AURA_MOUNTED)
-                    pPlayer->learnSpell(sSpell->Id);
+                // Check if the spell is in the excluded list before learning it
+                if (excludedSpellIds.find(i) == excludedSpellIds.end())
+                {
+                    auto sSpell = sSpellStore.LookupEntry(i);
+                    if (sSpell->Effect[0] == SPELL_EFFECT_APPLY_AURA && sSpell->EffectApplyAuraName[0] == SPELL_AURA_MOUNTED)
+                        pPlayer->learnSpell(sSpell->Id);
+                }
             }
         }
     }

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -2,17 +2,29 @@
 #include "ScriptMgr.h"
 #include "Chat.h"
 #include "Player.h"
+#include <sstream>
+#include <string>
 
 class AccountMounts : public PlayerScript
 {
     static const bool limitrace = true; // This set to true will only learn mounts from chars on the same team, do what you want.
 
-    // Define a list of SpellIDs to exclude from being learned account-wide.
-    std::set<uint32> excludedSpellIds = {470, 578, 6777, 66847, 17464, 18989, 10969, 10796, 35020, 34406}; // Add the SpellIDs you want to exclude here.
+    // Define a list of SpellIDs in config file to exclude from being learned account-wide.
+    std::set<uint32> excludedSpellIds;
 
 public:
-    AccountMounts() : PlayerScript("AccountMounts") { }
-
+    AccountMounts() : PlayerScript("AccountMounts") 
+    {
+        // Load excluded spell IDs from config
+        std::string excludedSpellsStr = sConfigMgr->GetStringDefault("Account.Mounts.ExcludedSpellIDs", "");
+        std::istringstream spellStream(excludedSpellsStr);
+        std::string spellIdStr;
+        while (std::getline(spellStream, spellIdStr, ',')) {
+            uint32 spellId = std::stoul(spellIdStr);
+            excludedSpellIds.insert(spellId);
+        }
+    }
+    
     void OnLogin(Player* pPlayer)
     {
         if (sConfigMgr->GetOption<bool>("Account.Mounts.Enable", true))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Allow to exclude spell IDs from the module

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
#### Build and Compatibility:
Compiled successfully without errors on Ubuntu 22.04.
### In-Game Functionality Verification:
#### Module Configuration and Activation:
- Excluded Spell ID 470 in the configuration file.
- Enabled the module for in-game testing.
#### Exclusion Test:
- Executed .learn 470 on an existing character; confirmed the spell was correctly taught.
- Created a new character to verify it did not automatically learn the excluded spell, confirming successful exclusion.
#### Inclusion Test:
- Applied .learn 578 on a character to learn a non-excluded spell.
- Switched between characters to verify the new spell was learned appropriately, confirming the module's selective exclusion works as intended.

#### Outcome:
- The module functions as expected, demonstrating compatibility with the operating system and adherence to configured exclusion rules.

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->
1. Update the module's configuration file by adding specific mount spell IDs to the exclusion list.
3. Login with a character and use the .learn command followed by one of the excluded spell IDs to attempt learning the spell.
4. Switch to another character and verify that the previously learned spell is not automatically learned or available, confirming the exclusion works as intended.